### PR TITLE
Translate register

### DIFF
--- a/src/main/resources/templates/georchestra/fragments/pmlinks.html
+++ b/src/main/resources/templates/georchestra/fragments/pmlinks.html
@@ -36,7 +36,9 @@
             <br><br>
         </form>
         <div th:unless="${passwordManagementEnabled}" id="resetPasswordLink">
-            <a href="/console/account/new">S'inscrire</a> -
+            <a href="/console/account/new">
+                <span th:utext="#{screen.welcome.button.register}">Register</span>
+            </a> -
             <span th:utext="#{screen.pm.button.forgotpwd('/console/account/passwordRecovery')}">Forgot your password?</span>
         </div>
     <p/>


### PR DESCRIPTION
PR translates "register" link using default translation "S'enregistrer" (for now). If we want to change default translations, we can do so by overwriting `messages_FR.properties` in `ressources` of this theme repo.