### PR TITLE
Do not display service on login screen

### DIFF
--- a/src/main/resources/static/themes/georchestra/css/cas.css
+++ b/src/main/resources/static/themes/georchestra/css/cas.css
@@ -596,8 +596,7 @@ text-align: justify;
 }
 
 #serviceui {
-    background-color: #17a3b844;
-    border-radius: 4px;
+    display: none;
 }
 
 #heroimg {


### PR DESCRIPTION
Untested, but PR should hide the green rectangle displaying the service.

![serviceui](https://user-images.githubusercontent.com/6329425/158199884-c00e22d4-044b-454a-9c4d-69b5447710db.png)
'