### PR TITLE
add dependencies for memcached ticket registry support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     implementation "org.apereo.cas:cas-server-support-ldap:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-pac4j-webflow:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-oauth-webflow:${casServerVersion}"
+    implementation "org.apereo.cas:cas-server-support-memcached-core:${casServerVersion}"
+    implementation "org.apereo.cas:cas-server-support-memcached-ticket-registry:${casServerVersion}"
+    implementation "org.apereo.cas:cas-server-support-memcached-spy:${casServerVersion}"
 
     providedCompile "org.springframework.boot:spring-boot:${springBootVersion}"
 }


### PR DESCRIPTION
with that, i have the jars for cas tickets in memcached (untested at runtime yet)
```
[22/06 11:21] landry@ids3.fluela:/etc/georchestra/cas $unzip -l /usr/share/lib/georchestra-cas/cas.war |grep memcache
     6420  2022-06-22 11:05   WEB-INF/lib/cas-server-support-memcached-ticket-registry-6.3.7.4.jar
    23156  2022-06-22 11:05   WEB-INF/lib/cas-server-support-memcached-core-6.3.7.4.jar
      709  2022-06-22 11:05   WEB-INF/lib/cas-server-support-memcached-spy-6.3.7.4.jar
   473774  2022-06-14 15:54   WEB-INF/lib/spymemcached-2.12.3.jar
```

cf https://apereo.github.io/cas/6.4.x/ticketing/Memcached-Ticket-Registry.html

sample config in `cas/config/cas.properties` (cf https://apereo.github.io/cas/6.4.x/ticketing/Memcached-Ticket-Registry.html#configuration, untested too yet):
```
cas.ticket.registry.memcached.memcached.servers=memcached:11211
cas.ticket.registry.memcached.memcached.locator-type=ARRAY_MOD
cas.ticket.registry.memcached.memcached.failure-mode=Redistribute
cas.ticket.registry.memcached.memcached.hash-algorithm=FNV1_64_HASH
```