### PR TITLE
Addding sentry & cas-oidc-provider as dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
         classpath "io.freefair.gradle:lombok-plugin:${project.gradleLombokPluginVersion}"
 
         classpath "com.netflix.nebula:gradle-ospackage-plugin:9.0.0"
+
     }
 }
 
@@ -86,6 +87,8 @@ dependencies {
     implementation "org.apereo.cas:cas-server-support-ldap:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-pac4j-webflow:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-oauth-webflow:${casServerVersion}"
+    implementation "org.apereo.cas:cas-server-support-oidc:${casServerVersion}"
+    implementation group: 'io.sentry', name: 'sentry-log4j2', version: '6.10.0'
 
     providedCompile "org.springframework.boot:spring-boot:${springBootVersion}"
 }


### PR DESCRIPTION
These are not needed per se, but:

* the first one allows CAS to act as an OIDC provider, which could be useful if the SP is being replaced by the geOrchestra gateway but we still want to have our own identity provier.
* The second one is sometimes used by Camptocamp deployments to be able to send some issues into a Sentry.io instance