### PR TITLE
Favicon location

### DIFF
--- a/src/main/resources/templates/georchestra/layout.html
+++ b/src/main/resources/templates/georchestra/layout.html
@@ -20,8 +20,7 @@
     <span th:remove="tag" th:each="file : ${#strings.arraySplit(#themes.code('cas.standard.css.file'), ',')}">
         <link rel="stylesheet" type="text/css" href="../static/css/cas.css" th:href="@{${file}}" />
     </span>
-    <link rel="shortcut icon"
-        th:href="@{${#strings.defaultString(#themes.code('cas.favicon.file'), '/favicon.ico')}}" />
+    <link rel="shortcut icon" href="/favicon.ico"/>
 </head>
 
 <body>


### PR DESCRIPTION
# Favicon location

This PR is used to change favicon to point to `/favicon.ico` url.

This is supposed to be the default location for geOrchestra's favicon.

Resolving : 
- https://github.com/georchestra/georchestra/issues/4087

## Altering default behavior.

In order to change default location, we can implement it with a custom script, modyfing `/favicon.ico` infollowing html files to the new location using  a tool like `sed`. 

Files to change : 
```
# /var/lib/jetty
./webapps/cas/WEB-INF/classes/templates/georchestra/layout.html
```