### PR TITLE
adding cas-saml-idp as dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     implementation "org.apereo.cas:cas-server-support-pac4j-webflow:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-oauth-webflow:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-oidc:${casServerVersion}"
+    implementation "org.apereo.cas:cas-server-support-saml-idp:${casServerVersion}"
     implementation group: 'io.sentry', name: 'sentry-log4j2', version: '6.10.0'
 
     providedCompile "org.springframework.boot:spring-boot:${springBootVersion}"


### PR DESCRIPTION
So that cas can act as a SAML identity provider.

Tests: runtime tested without touching anything in the configuration, no extra configuration variable seems needed in the properties file which would prevent CAS from booting (as opposed to the previous contribution with oidc).

Needs more thorough tests though.
 