### PR TITLE
excluding transitive dependency to log4j2 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,9 @@ dependencies {
     implementation "org.apereo.cas:cas-server-support-oauth-webflow:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-oidc:${casServerVersion}"
     implementation "org.apereo.cas:cas-server-support-saml-idp:${casServerVersion}"
-    implementation group: 'io.sentry', name: 'sentry-log4j2', version: '6.10.0'
+    implementation(group: 'io.sentry', name: 'sentry-log4j2', version: '6.10.0') {
+      exclude group: 'org.apache.logging.log4j'
+    }
 
     providedCompile "org.springframework.boot:spring-boot:${springBootVersion}"
 }


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/3838#issuecomment-2154570619 for the motivations.

Tests:
build time, generated war does not contain the problematic dependency anymore:

```
% jar tf cas.war | grep log4j
WEB-INF/lib/sentry-log4j2-6.10.0.jar
WEB-INF/lib/log4j-web-2.18.0.jar
WEB-INF/lib/spring-boot-starter-log4j2-2.7.3.jar
WEB-INF/lib/log4j-jcl-2.18.0.jar
WEB-INF/lib/log4j-layout-template-json-2.18.0.jar
WEB-INF/lib/log4j-core-2.18.0.jar
WEB-INF/lib/log4j-jul-2.18.0.jar
WEB-INF/lib/log4j-slf4j-impl-2.18.0.jar
WEB-INF/lib/log4j-api-2.18.0.jar
```