### PR TITLE
deb - using 0-23 range for hours in package name/version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,5 +153,5 @@ def getDebianVersion() {
     def commitId = 'git rev-parse --verify --short HEAD'.execute().text.trim()
     def branchName = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
 
-    "${casServerVersion}.${branchName}.${new Date().format('yyyyMMddhhmm')}~${commitId}"
+    "${casServerVersion}.${branchName}.${new Date().format('yyyyMMddHHmm')}~${commitId}"
 }


### PR DESCRIPTION
the filename of the debian package being generated contains a timestamp. This timestamp is checked by reprepro when trying to publish the package to figure out if a potential already present package in the repository should be replaced by the new one.

If we use 'hh' instead of 'HH' in the date formatting call, and:

* we generate a package at 12:15
* we generate a new version at 14:15

then the expected new version will be timestamped as <date>0215 instead of <date>1415 and won't replace the version from 12:15.

encountered today on buildbot:

```
Skipping inclusion of 'georchestra-cas' '6.6.15.master.202406070226~112d06e' in 'master|main|arm64', as it has already '6.6.15.master.202406071205~20cbb9c'.
```

Using 0-23 range when formatting the hour of the day should solve the issue with publishing the package.