### PR TITLE
flag configuration files as such in the debian package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,10 @@ task deb(type: Deb) {
     from ("$buildDir/datadir/cas") {
       into '/etc/georchestra/cas'
     }
+    configurationFile('/etc/georchestra/cas/config/cas.properties')
+    configurationFile('/etc/georchestra/cas/config/log4j2.xml')
+    configurationFile('/etc/georchestra/cas/services/georchestra-1001.json')
+    configurationFile('/etc/georchestra/cas/services/oauth-2001.json')
     link "/usr/share/lib/georchestra-cas/cas-generic.war", "/usr/share/lib/georchestra-cas/cas.war"
 }
 


### PR DESCRIPTION
this fixes the annoying issue that each time `georchestra-cas` debian package is installed/upgraded, the modified/customized config files in `/etc/georchestra/cas` are overriden by the ones from the debian package.

before:
```
$dpkg-query --showformat='${Conffiles}\n' --show georchestra-cas
# nothing
```
install/upgrade with a package built from this commit, it correctly asks if we want to override our config files, defaulting to N:
```
Unpacking georchestra-cas (6.6.15.24.0.x-craig.202503061644~f9ce364) over (6.6.15.24.0.x-craig.202501221620~0b5b71d) ...
Configuration file '/etc/georchestra/cas/config/cas.properties'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** cas.properties (Y/I/N/O/D/Z) [default=N] ?

Configuration file '/etc/georchestra/cas/config/log4j2.xml'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** log4j2.xml (Y/I/N/O/D/Z) [default=N] ?

Configuration file '/etc/georchestra/cas/services/georchestra-1001.json'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** georchestra-1001.json (Y/I/N/O/D/Z) [default=N] ?
```
and after, those files are correctly registered as config files from debian's POV:
```
$dpkg-query --showformat='${Conffiles}\n' --show georchestra-cas
 /etc/georchestra/cas/config/cas.properties ee9e3c192a2b392c286306a1e699f4c9
 /etc/georchestra/cas/config/log4j2.xml 208538a4adf30f965225d34effec0e8f
 /etc/georchestra/cas/services/georchestra-1001.json 841e27d3253ac6c385844088f3ea4b14
 /etc/georchestra/cas/services/oauth-2001.json newconffile
```